### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           version=$(echo "${{ github.event.release.tag_name }}" | sed "s/^sed-//")
           echo "version=$version" >> $GITHUB_OUTPUT
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@main
         with:
           identifier: mbuilov.sed
           version: ${{ steps.extract_version.outputs.version }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,21 @@
+name: Publish to Winget
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          version=$(echo "${{ github.event.release.tag_name }}" | sed "s/^sed-//")
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: mbuilov.sed
+          version: ${{ steps.extract_version.outputs.version }}
+          installers-regex: 'sed-([\d.]+)-(x86|x64)\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
- Related to https://github.com/mbuilov/sed-windows/issues/11#issuecomment-1751610576

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

I have just added sed to Winget (https://github.com/microsoft/winget-pkgs/pull/122053), and this workflow should be used to update it.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`. You can go to this URL to create it: https://github.com/settings/tokens/new?scopes=public_repo

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @mbuilov. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).